### PR TITLE
Added iflipb

### DIFF
--- a/.emacs-custom.el
+++ b/.emacs-custom.el
@@ -6,6 +6,7 @@
  '(blink-cursor-mode nil)
  '(cua-rectangle-mark-key (kbd "C-x <C-return>"))
  '(helm-ff-transformer-show-only-basename nil)
+ '(iflipb-ignore-buffers nil)
  '(minimap-window-location (quote right))
  '(ns-pop-up-frames nil)
  '(projectile-ack-function (quote ag))

--- a/init.el
+++ b/init.el
@@ -70,6 +70,7 @@
    (cons 'diff-hl melpa)
    (cons 'free-keys melpa)
    (cons 'syslog-mode melpa)
+   (cons 'iflipb melpa)
    )
   (if (>= emacs-major-version 24)
       (packages-install

--- a/parts/005-buffer-management.el
+++ b/parts/005-buffer-management.el
@@ -69,3 +69,7 @@ Including indent-buffer, which should not be called automatically on save."
           (select-window first-win)
           (if this-win-2nd (other-window 1))))))
 (global-set-key (kbd "C-x w t") 'my/rotate-windows)
+
+(require 'iflipb)
+(global-set-key (kbd "M-h") 'iflipb-next-buffer)
+(global-set-key (kbd "M-H") 'iflipb-previous-buffer)

--- a/parts/025-org-mode-setup.el
+++ b/parts/025-org-mode-setup.el
@@ -5,7 +5,8 @@
             (define-key org-mode-map [(meta left)]    nil)
             (define-key org-mode-map [(meta right)]   nil)
             (define-key org-mode-map [(meta down)]    nil)
-            (define-key org-mode-map [(meta up)]   nil))
+            (define-key org-mode-map [(meta up)]   nil)
+            (define-key org-mode-map (kbd "M-h")    nil))
           'append)
 
 (defun myorg-update-parent-cookie ()


### PR DESCRIPTION
http://www.emacswiki.org/emacs/iflipb

I don't consider it as a replacement for IDO but rather an addition. iflipb is more convenient than IDO when you want to jump back and forth quickly between 2 or 3 buffers.

I disabled org-mode's M-h in favor of iflipb since I don't use that binding in org-mode. If you do use it then we should find another key bind.
